### PR TITLE
ADX-281 Force file file download when clicking download.

### DIFF
--- a/ckanext/file_uploader_ui/templates/package/resource_read.html
+++ b/ckanext/file_uploader_ui/templates/package/resource_read.html
@@ -6,19 +6,27 @@
 {% if res.url and h.is_url(res.url) %}
   <li>
     <div class="btn-group">
-    <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
       {% if res.resource_type in ('listing', 'service') %}
-        <i class="fa fa-eye"></i> {{ _('View') }}
+        <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+          <i class="fa fa-eye"></i> {{ _('View') }}
+        </a>
       {% elif  res.resource_type == 'api' %}
-        <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+        <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+          <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+        </a>
       {% elif res.url_type == 'file_uploader_ui' %}
-        <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+        <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" download>
+          <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+        </a>
       {% elif (not res.has_views or not res.can_be_previewed) and not res.url_type == 'upload' %}
-        <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+        <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+          <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+        </a>
       {% else %}
-        <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+        <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" download>
+          <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+        </a>
       {% endif %}
-    </a>
      {% block download_resource_button %}
       {%if res.datastore_active %}
     <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
@@ -27,13 +35,13 @@
     <ul class="dropdown-menu">
       <li>
         <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, bom=True) }}"
-          target="_blank"><span>CSV</span></a>
+          target="_blank" download><span>CSV</span></a>
         <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='tsv', bom=True) }}"
-          target="_blank"><span>TSV</span></a>
+          target="_blank" download><span>TSV</span></a>
         <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='json') }}"
-          target="_blank"><span>JSON</span></a>
+          target="_blank" download><span>JSON</span></a>
         <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='xml') }}"
-          target="_blank"><span>XML</span></a>
+          target="_blank" download><span>XML</span></a>
       </li>
     </ul>
     {%endif%}

--- a/ckanext/file_uploader_ui/templates/package/snippets/resource_item.html
+++ b/ckanext/file_uploader_ui/templates/package/snippets/resource_item.html
@@ -13,15 +13,17 @@
 </li>
 {% if res.url and h.is_url(res.url) %}
 <li>
-  <a href="{{ res.url }}" class="resource-url-analytics" target="_blank">
-    {% if res.has_views or res.url_type == 'upload' or res.url_type =='file_uploader_ui'%}
-      <i class="fa fa-arrow-circle-o-down"></i>
-      {{ _('Download') }}
-    {% else %}
-      <i class="fa fa-external-link"></i>
-      {{ _('Go to resource') }}
-    {% endif %}
+  {% if res.has_views or res.url_type == 'upload' or res.url_type =='file_uploader_ui'%}
+  <a href="{{ res.url }}" class="resource-url-analytics" target="_blank" download>
+    <i class="fa fa-arrow-circle-o-down"></i>
+    {{ _('Download') }}
   </a>
+  {% else %}
+  <a href="{{ res.url }}" class="resource-url-analytics" target="_blank">
+    <i class="fa fa-external-link"></i>
+    {{ _('Go to resource') }}
+  </a>
+  {% endif %}
 </li>
 {% endif %}
 {% if can_edit %}


### PR DESCRIPTION
This PR amends the download buttons for resources to ensure that if a file is to be downloaded, we force file download through inclusion of the `download` attribute in the `a` tag. 

This is in ckan-file-uploader because this extension has to completely override the relevant template parts to facility the bulk file upload process. 

Some times e.g. if the resource is a website, the resource is not to be downloaded, it is actually just to act as a web link, which is why there is a little more logic around this than we would think. Welcome quick suggestions for making the code more concise. 

Testing this would require some real front end testing, which we won't get our heads around before November. 
